### PR TITLE
Enable react query

### DIFF
--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -26,7 +26,7 @@ typescript:
   clientServerStatusCodesAsErrors: true
   defaultErrorName: APIError
   enableCustomCodeRegions: false
-  enableReactQuery: false
+  enableReactQuery: true
   enumFormat: union
   envVarPrefix: GUSTOEMBEDDED
   flattenGlobalSecurity: true


### PR DESCRIPTION
This change makes sure that Speakeasy generates react-query compatible hooks (requested by the react sdk team) in the generated library.