### PR TITLE
Adds local target to Speakeasy workflow file

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -10,6 +10,13 @@ sources:
             - location: gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml
         registry:
             location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas
+    GustoEmbedded-local:
+        inputs:
+            - location: ../Gusto-Partner-API/generated/embedded/api.v2024-04-01.embedded.yaml
+        overlays:
+            - location: gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml
+        registry:
+            location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-local
 targets:
     gusto-embedded:
         target: typescript
@@ -18,6 +25,16 @@ targets:
         publish:
             npm:
                 token: $npm_token
+        codeSamples:
+            registry:
+                location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-typescript-code-samples
+            labelOverride:
+                fixedValue: Typescript (SDK)
+            blocking: false
+    local:
+        target: typescript
+        source: GustoEmbedded-local
+        output: ./gusto_embedded
         codeSamples:
             registry:
                 location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-typescript-code-samples

--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -16,7 +16,7 @@ generation:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
 typescript:
-  version: 0.1.5
+  version: 0.1.11
   additionalDependencies:
     dependencies: {}
     devDependencies: {}


### PR DESCRIPTION
Adds a new target that we can use locally to quickly debug changes to the OpenAPI spec without having to get those changes merged into `main`. This should only be used locally, not in CI. It can be used by calling
```
speakeasy run --target local
```