### PR TITLE
Ensure we only build the gusto-embedded target

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -24,6 +24,7 @@ jobs:
       force: ${{ github.event.inputs.force }}
       mode: pr
       set_version: ${{ github.event.inputs.set_version }}
+      target: gusto-embedded
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
After adding the `local` target in [this PR](https://github.com/Gusto/gusto-typescript-client/pull/11), the github action, by default will run a build against each configured target. This change should force the action to only run against the specified target.

The workflow successfully ran https://github.com/Gusto/gusto-typescript-client/actions/runs/13164099383/job/36739901902