### PR TITLE
Fixes publishing job

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,20 +2,20 @@ speakeasyVersion: 1.486.0
 sources:
     GustoEmbedded-OAS:
         sourceNamespace: gusto-embedded-oas
-        sourceRevisionDigest: sha256:b05154b12af033d54101a730c6313c976877ab04326e60920dcc6df31320cebc
+        sourceRevisionDigest: sha256:46824bbbf8fe4411381b69b7d7bc64b68f2701ee8f6501dfab22c6e4002883ee
         sourceBlobDigest: sha256:5c5f2da70899ad4308b8fe528bc640da4e9082ea66efde70d6c474eb044552a4
         tags:
             - latest
-            - speakeasy-sdk-regen-1738878869
+            - speakeasy-sdk-regen-1738880555
             - "2024-04-01"
 targets:
     gusto-embedded:
         source: GustoEmbedded-OAS
         sourceNamespace: gusto-embedded-oas
-        sourceRevisionDigest: sha256:b05154b12af033d54101a730c6313c976877ab04326e60920dcc6df31320cebc
+        sourceRevisionDigest: sha256:46824bbbf8fe4411381b69b7d7bc64b68f2701ee8f6501dfab22c6e4002883ee
         sourceBlobDigest: sha256:5c5f2da70899ad4308b8fe528bc640da4e9082ea66efde70d6c474eb044552a4
         codeSamplesNamespace: gusto-embedded-oas-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:e3310fc47d286e67aab2fca48d537375001004dfbcf83fe3ecbc70068c7398a1
+        codeSamplesRevisionDigest: sha256:3926c1196f7e75797ee9d05f1da1df8728e54fb534b5dffa1764679c4b103074
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -35,6 +35,11 @@ targets:
         target: typescript
         source: GustoEmbedded-local
         output: ./gusto_embedded
+        # Maybe a bug in speakeay's tool, but the publishing GH action
+        # doesn't work unless all targets have a configured publish section.
+        publish:
+            npm:
+                token: ''
         codeSamples:
             registry:
                 location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-typescript-code-samples

--- a/gusto_embedded/.speakeasy/gen.lock
+++ b/gusto_embedded/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: "2024-04-01"
   speakeasyVersion: 1.486.0
   generationVersion: 2.505.0
-  releaseVersion: 0.1.11
-  configChecksum: e1d7b7204b7ec25286a4c2dd9aa4b56d
+  releaseVersion: 0.1.18
+  configChecksum: b77aaf0cea460fc35a217fc36e0fe618
   repoURL: https://github.com/Gusto/gusto-typescript-client.git
   repoSubDirectory: gusto_embedded
   installationURL: https://gitpkg.now.sh/Gusto/gusto-typescript-client/gusto_embedded

--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -16,7 +16,7 @@ generation:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
 typescript:
-  version: 0.1.11
+  version: 0.1.18
   additionalDependencies:
     dependencies: {}
     devDependencies: {}

--- a/gusto_embedded/RELEASES.md
+++ b/gusto_embedded/RELEASES.md
@@ -19,3 +19,13 @@ Based on:
 - [typescript v0.1.11] gusto_embedded
 ### Releases
 - [NPM v0.1.11] https://www.npmjs.com/package/@gusto/embedded-api/v/0.1.11 - gusto_embedded
+
+## 2025-02-06 22:22:18
+### Changes
+Based on:
+- OpenAPI Doc  
+- Speakeasy CLI 1.486.0 (2.505.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v0.1.18] gusto_embedded
+### Releases
+- [NPM v0.1.18] https://www.npmjs.com/package/@gusto/embedded-api/v/0.1.18 - gusto_embedded

--- a/gusto_embedded/jsr.json
+++ b/gusto_embedded/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@gusto/embedded-api",
-  "version": "0.1.11",
+  "version": "0.1.18",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/gusto_embedded/package-lock.json
+++ b/gusto_embedded/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gusto/embedded-api",
-  "version": "0.1.11",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gusto/embedded-api",
-      "version": "0.1.11",
+      "version": "0.1.18",
       "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@tanstack/react-query": "^5.61.4",

--- a/gusto_embedded/package.json
+++ b/gusto_embedded/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/embedded-api",
-  "version": "0.1.11",
+  "version": "0.1.18",
   "author": "Speakeasy",
   "main": "./index.js",
   "sideEffects": false,

--- a/gusto_embedded/src/lib/config.ts
+++ b/gusto_embedded/src/lib/config.ts
@@ -60,8 +60,8 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "2024-04-01",
-  sdkVersion: "0.1.11",
+  sdkVersion: "0.1.18",
   genVersion: "2.505.0",
   userAgent:
-    "speakeasy-sdk/typescript 0.1.11 2.505.0 2024-04-01 @gusto/embedded-api",
+    "speakeasy-sdk/typescript 0.1.18 2.505.0 2024-04-01 @gusto/embedded-api",
 } as const;


### PR DESCRIPTION
when there are multiple targets present, we must define a publish config for each one. Otherwise, the Publishing Github Action fails to trigger. I've filed this as a bug with Speakeasy, but this is our workaround for now.