### PR TITLE
set responseFormat to envelope

### DIFF
--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -49,6 +49,6 @@ typescript:
   moduleFormat: commonjs
   outputModelSuffix: output
   packageName: '@gusto/embedded-api'
-  responseFormat: flat
+  responseFormat: envelope
   templateVersion: v2
   useIndexModules: true


### PR DESCRIPTION
This will allow consumers of the client to access metadata such as header values from a response object. This is important for pagination which relies on headers.