### PR TITLE
[GWS-4127] Pass headers into the ReactSDKProvider

### DIFF
--- a/gusto_embedded/src/ReactSDKProvider.tsx
+++ b/gusto_embedded/src/ReactSDKProvider.tsx
@@ -12,7 +12,7 @@ export function ReactSDKProvider({
   children,
 }: {
   url: string;
-  headers?: Record<string, string | number>;
+  headers?: Headers;
   children: React.ReactNode;
 }) {
   const httpClientWithHeaders = new HTTPClient({

--- a/gusto_embedded/src/ReactSDKProvider.tsx
+++ b/gusto_embedded/src/ReactSDKProvider.tsx
@@ -1,24 +1,51 @@
+import { HTTPClient } from "./lib/http.js";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { GustoEmbeddedProvider } from "./react-query/index.js";
 import { GustoEmbeddedCore } from "./core.js";
 
 //Reexporting useQueryClient to be available in consumer application without direct react-query dependency
-export { useQueryClient } from "@tanstack/react-query"
+export { useQueryClient } from "@tanstack/react-query";
 
-export function ReactSDKProvider({ url, children }: { url: string, children: React.ReactNode }) {
-    const queryClient = new QueryClient();
-    const gustoClient = new GustoEmbeddedCore({
-        serverURL: url,
-    },)
-    queryClient.setQueryDefaults(['@gusto/embedded-api'], { retry: false })
-    queryClient.setMutationDefaults(['@gusto/embedded-api'], { retry: false })
+export function ReactSDKProvider({
+  url,
+  headers,
+  children,
+}: {
+  url: string;
+  headers?: Record<string, string | number>;
+  children: React.ReactNode;
+}) {
+  const httpClientWithHeaders = new HTTPClient({
+    fetcher: async (request) => {
+      if (request instanceof Request) {
+        const requestWithHeaders = {
+          ...request,
+          headers: {
+            ...request.headers,
+            ...headers,
+          },
+        };
+        return fetch(requestWithHeaders);
+      }
+      return fetch(request);
+    },
+  });
 
+  const queryClient = new QueryClient();
+  const gustoClient = new GustoEmbeddedCore({
+    serverURL: url,
+    httpClient: httpClientWithHeaders,
+  });
+  queryClient.setQueryDefaults(["@gusto/embedded-api"], { retry: false });
+  queryClient.setMutationDefaults(["@gusto/embedded-api"], { retry: false });
 
-    return (<QueryClientProvider client={queryClient} >
-        <GustoEmbeddedProvider client={gustoClient}>
-            {children}
-        </GustoEmbeddedProvider>
-    </QueryClientProvider>)
+  return (
+    <QueryClientProvider client={queryClient}>
+      <GustoEmbeddedProvider client={gustoClient}>
+        {children}
+      </GustoEmbeddedProvider>
+    </QueryClientProvider>
+  );
 }
 
-export default { ReactSDKProvider }
+export default { ReactSDKProvider };

--- a/gusto_embedded/src/ReactSDKProvider.tsx
+++ b/gusto_embedded/src/ReactSDKProvider.tsx
@@ -17,16 +17,14 @@ export function ReactSDKProvider({
 }) {
   const httpClientWithHeaders = new HTTPClient({
     fetcher: async (request) => {
-      if (request instanceof Request) {
-        const requestWithHeaders = {
-          ...request,
-          headers: {
-            ...request.headers,
-            ...headers,
-          },
-        };
-        return fetch(requestWithHeaders);
+      if (request instanceof Request && headers) {
+        headers.forEach((headerValue, headerName) => {
+          if (headerValue) {
+            request.headers.set(headerName, headerValue);
+          }
+        });
       }
+
       return fetch(request);
     },
   });


### PR DESCRIPTION
Ticket: https://gustohq.atlassian.net/browse/GWS-4127

Allows passing arbitrary headers into a request made by the react SDK by setting up a custom http client.