### PR TITLE
Fixes broken publish job

### DIFF
--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -22,3 +22,4 @@ jobs:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+      openapi_doc_auth_token: ${{ secrets.OPENAPI_DOC_AUTH_TOKEN }}


### PR DESCRIPTION
Worked with Speakeasy to debug this job. It has been broken for a couple of weeks now.
* add openapi_doc_auth_token to publish job