### PR TITLE
Adds local target

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -12,6 +12,13 @@ sources:
               authSecret: $openapi_doc_auth_token
         registry:
             location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas
+    GustoEmbedded-local:
+        inputs:
+            - location: ../Gusto-Partner-API/generated/embedded/api.v2024-04-01.embedded.yaml
+        overlays:
+            - location: ../Gusto-Partner-API/.speakeasy/speakeasy-modifications-overlay.yaml
+        registry:
+            location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-local
 targets:
     gusto-embedded:
         target: typescript
@@ -25,3 +32,13 @@ targets:
                 location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-typescript-code-samples
             labelOverride:
                 fixedValue: Typescript (SDK)
+    local:
+        target: typescript
+        source: GustoEmbedded-local
+        output: ./gusto_embedded
+        codeSamples:
+            registry:
+                location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-local-typescript-code-samples
+            labelOverride:
+                fixedValue: Typescript (SDK)
+            blocking: false


### PR DESCRIPTION
Adds the local target to the workflow.yaml file so it will permanently be available and not require extra documentation to set up each time we need to use it. This used to break the Code Generation github action, but I guess Speakeasy fixed that bug. This will have no impact on the code generation job run on github, but will be a useful tool for local development when testing changes to the Open API specs.

After merging this, I will remove the sections of the Speakeasy documentation describing how to add this manually