### PR TITLE
set up local target in local workflow file

### DIFF
--- a/.speakeasy/workflow.local.yaml
+++ b/.speakeasy/workflow.local.yaml
@@ -1,0 +1,19 @@
+sources:
+  GustoEmbedded-local:
+    inputs:
+      - location: ../Gusto-Partner-API/generated/embedded/api.v2024-04-01.embedded.yaml
+    overlays:
+      - location: ../Gusto-Partner-API/.speakeasy/speakeasy-modifications-overlay.yaml
+    registry:
+      location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-local
+targets:
+  local:
+    target: typescript
+    source: GustoEmbedded-local
+    output: ./gusto_embedded
+    codeSamples:
+      registry:
+        location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-local-typescript-code-samples
+      labelOverride:
+        fixedValue: Typescript (SDK)
+      blocking: false

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -12,13 +12,6 @@ sources:
               authSecret: $openapi_doc_auth_token
         registry:
             location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas
-    GustoEmbedded-local:
-        inputs:
-            - location: ../Gusto-Partner-API/generated/embedded/api.v2024-04-01.embedded.yaml
-        overlays:
-            - location: ../Gusto-Partner-API/.speakeasy/speakeasy-modifications-overlay.yaml
-        registry:
-            location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-local
 targets:
     gusto-embedded:
         target: typescript
@@ -32,13 +25,3 @@ targets:
                 location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-typescript-code-samples
             labelOverride:
                 fixedValue: Typescript (SDK)
-    local:
-        target: typescript
-        source: GustoEmbedded-local
-        output: ./gusto_embedded
-        codeSamples:
-            registry:
-                location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-local-typescript-code-samples
-            labelOverride:
-                fixedValue: Typescript (SDK)
-            blocking: false


### PR DESCRIPTION
The [Publish workflow is broken](https://github.com/Gusto/gusto-typescript-client/actions/runs/18016936257) because of the new `local` target. I asked Speakeasy to build us a workaround, so we can have a working github action and a `local` target that the React SDK team can use to quickly iterate on the SDK while making local changes to the OpenAPI specs. They came up with this `workflow.local.yaml` file where we can define any local build configs.

Test that this works locally by running `speakeasy run --tartget=local`
Once this has merged we can test the Publish workflow in Github actions

See this thread in the Speakeasy slack group https://speakeasy-dev.slack.com/archives/C04PNBJ8YG6/p1758213566366549