### PR TITLE
[GWS-5560] add slack webhook url to notify of speakeasy build failures

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -31,3 +31,4 @@ jobs:
       npm_token: ${{ secrets.NPM_TOKEN }}
       openapi_doc_auth_token: ${{ secrets.OPENAPI_DOC_AUTH_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Adds this repository's SLACK_WEBHOOK_URL [secret](https://github.com/Gusto/gusto-typescript-client/settings/secrets/actions) to the `secrets` variables for the sdk generation GHA. The slack webhook url should link to #emb-api-infra-eng-alerts ([here](https://gustohq.slack.com/archives/C07RKJJ5QQL/p1759436794425199)).

<img width="1144" height="475" alt="Screenshot 2025-10-02 at 1 37 17 PM" src="https://github.com/user-attachments/assets/1c7d119b-3740-41a2-bb92-0b10f306f531" />


JIRA: https://gustohq.atlassian.net/browse/GWS-5560