### PR TITLE
test build failure

### DIFF
--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -25,7 +25,6 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 typescript:
-  version: 0.7.1
   additionalDependencies:
     dependencies: {}
     devDependencies: {}


### PR DESCRIPTION
This PR intentionally introduces a change to break the Speakeasy build and test our Slack integration alerts for Speakeasy build failures. It should not pass CI and will ultimately not be deployed.