### PR TITLE
capitalize SLACK_WEBHOOK_URL

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -31,4 +31,4 @@ jobs:
       npm_token: ${{ secrets.NPM_TOKEN }}
       openapi_doc_auth_token: ${{ secrets.OPENAPI_DOC_AUTH_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Correction to this [initial PR](https://github.com/Gusto/gusto-typescript-client/pull/75). The speakeasy GHA expects a capitalized SLACK_WEBHOOK_URL variable