### PR TITLE
chore: bump API version to 2025-11-15

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,27 +1,51 @@
+---
 workflowVersion: 1.0.0
 speakeasyVersion: latest
 sources:
-    GustoEmbedded-OAS:
-        inputs:
-            - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2025-06-15.embedded.yaml
-              authHeader: Authorization
-              authSecret: $openapi_doc_auth_token
-        overlays:
-            - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
-              authHeader: Authorization
-              authSecret: $openapi_doc_auth_token
-        registry:
-            location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas
+  GustoEmbedded-OAS:
+    inputs:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2025-11-15.embedded.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    overlays:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    registry:
+      location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas
+  GustoEmbedded-OAS-v2025-06-15:
+    inputs:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2025-06-15.embedded.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    overlays:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    registry:
+      location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas
 targets:
-    gusto-embedded:
-        target: typescript
-        source: GustoEmbedded-OAS
-        output: ./gusto_embedded
-        publish:
-            npm:
-                token: $npm_token
-        codeSamples:
-            registry:
-                location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-typescript-code-samples
-            labelOverride:
-                fixedValue: Typescript (SDK)
+  gusto-embedded:
+    target: typescript
+    source: GustoEmbedded-OAS
+    output: "./gusto_embedded"
+    publish:
+      npm:
+        token: "$npm_token"
+    codeSamples:
+      registry:
+        location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-typescript-code-samples
+      labelOverride:
+        fixedValue: Typescript (SDK)
+  gusto-embedded-v2025-06-15:
+    target: typescript
+    source: GustoEmbedded-OAS-v2025-06-15
+    output: "./gusto_embedded_v_2025_06_15"
+    publish:
+      npm:
+        token: "$npm_token"
+    codeSamples:
+      registry:
+        location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-typescript-code-samples
+      labelOverride:
+        fixedValue: Typescript (SDK)


### PR DESCRIPTION
## Summary
- Updates workflow.yaml to use API version `2025-11-15`
- Preserves previous version SDK in versioned directories (e.g., `gusto_embedded_v_YYYY_MM_DD`)
- Adds versioned source and target entries to workflow.yaml for backwards compatibility

## Notes
Merge the Gusto-Partner-API PR first before merging this PR.