### PR TITLE
feat: add MIT license to Speakeasy SDK generation

### DIFF
--- a/.speakeasy/workflow.local.yaml
+++ b/.speakeasy/workflow.local.yaml
@@ -1,0 +1,13 @@
+workflowVersion: 1.0.0
+speakeasyVersion: latest
+sources:
+  GustoEmbedded-local:
+    inputs:
+      - location: ../Gusto-Partner-API/generated/embedded/api.v2025-06-15.embedded.yaml
+    overlays:
+      - location: ../Gusto-Partner-API/.speakeasy/speakeasy-modifications-overlay.yaml
+targets:
+  local:
+    target: typescript
+    source: GustoEmbedded-local
+    output: ./gusto_embedded

--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -27,10 +27,6 @@ generation:
   requestBodyFieldName: ""
   versioningStrategy: automatic
   persistentEdits: {}
-  license:
-    disabled: false
-    licenseType: MIT
-    companyName: Gusto
   tests:
     generateTests: true
     generateNewTests: false
@@ -42,7 +38,8 @@ typescript:
     dependencies: {}
     devDependencies: {}
     peerDependencies: {}
-  additionalPackageJSON: {}
+  additionalPackageJSON:
+    license: MIT
   additionalScripts: {}
   alwaysIncludeInboundAndOutbound: false
   author: Speakeasy

--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -27,6 +27,10 @@ generation:
   requestBodyFieldName: ""
   versioningStrategy: automatic
   persistentEdits: {}
+  license:
+    disabled: false
+    licenseType: MIT
+    companyName: Gusto
   tests:
     generateTests: true
     generateNewTests: false

--- a/gusto_embedded/LICENSE
+++ b/gusto_embedded/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Gusto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Adds `typescript.additionalPackageJSON.license: MIT` to `gen.yaml` — the [correct location](https://www.speakeasy.com/docs/speakeasy-reference/generation/ts-config) per Speakeasy docs, which sets \`"license": "MIT"\` in \`package.json\`
- Manually adds \`gusto_embedded/LICENSE\` (MIT)
- Adds \`.speakeasy/workflow.local.yaml\` for running \`speakeasy run --target=local\` during local development

## Test plan

- [x] Confirm \`gusto_embedded/package.json\` has \`"license": "MIT"\` after the next \`speakeasy run\`
- [x] Run \`speakeasy run --target=local\` locally and confirm generation succeeds