### PR TITLE
ci: add publish jobs for all versioned SDK targets

### DIFF
--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -5,40 +5,40 @@ permissions:
   pull-requests: write
   statuses: write
   id-token: write
-"on":
+'on':
   push:
     branches:
-      - main
+    - main
     paths:
-      - gusto_embedded/.speakeasy/gen.lock
-      - gusto_embedded_v_2025_11_15/.speakeasy/gen.lock
-      - gusto_embedded_v_2026_06_15/.speakeasy/gen.lock
+    - gusto_embedded/.speakeasy/gen.lock
+    - gusto_embedded_v_2025_11_15/.speakeasy/gen.lock
+    - gusto_embedded_v_2026_06_15/.speakeasy/gen.lock
   workflow_dispatch: {}
 jobs:
   publish-gusto-embedded:
     uses: Gusto/sdk-generation-action/.github/workflows/sdk-publish.yaml@main
     with:
       target: gusto-embedded
-      runs-on: "{\"group\": \"gusto-ubuntu-default\"}"
+      runs-on: '{"group": "gusto-ubuntu-default"}'
     secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      npm_token: ${{ secrets.NPM_TOKEN }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+      github_access_token: "${{ secrets.GITHUB_TOKEN }}"
+      npm_token: "${{ secrets.NPM_TOKEN }}"
+      speakeasy_api_key: "${{ secrets.SPEAKEASY_API_KEY }}"
   publish-gusto-embedded-v2025-11-15:
     uses: Gusto/sdk-generation-action/.github/workflows/sdk-publish.yaml@main
     with:
       target: gusto-embedded-v2025-11-15
-      runs-on: "{\"group\": \"gusto-ubuntu-default\"}"
+      runs-on: '{"group": "gusto-ubuntu-default"}'
     secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      npm_token: ${{ secrets.NPM_TOKEN }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+      github_access_token: "${{ secrets.GITHUB_TOKEN }}"
+      npm_token: "${{ secrets.NPM_TOKEN }}"
+      speakeasy_api_key: "${{ secrets.SPEAKEASY_API_KEY }}"
   publish-gusto-embedded-v2026-06-15:
     uses: Gusto/sdk-generation-action/.github/workflows/sdk-publish.yaml@main
     with:
       target: gusto-embedded-v2026-06-15
-      runs-on: "{\"group\": \"gusto-ubuntu-default\"}"
+      runs-on: '{"group": "gusto-ubuntu-default"}'
     secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      npm_token: ${{ secrets.NPM_TOKEN }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+      github_access_token: "${{ secrets.GITHUB_TOKEN }}"
+      npm_token: "${{ secrets.NPM_TOKEN }}"
+      speakeasy_api_key: "${{ secrets.SPEAKEASY_API_KEY }}"

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -11,11 +11,32 @@ permissions:
       - main
     paths:
       - gusto_embedded/.speakeasy/gen.lock
+      - gusto_embedded_v_2025_11_15/.speakeasy/gen.lock
+      - gusto_embedded_v_2026_06_15/.speakeasy/gen.lock
   workflow_dispatch: {}
 jobs:
-  publish:
+  publish-gusto-embedded:
     uses: Gusto/sdk-generation-action/.github/workflows/sdk-publish.yaml@main
     with:
+      target: gusto-embedded
+      runs-on: "{\"group\": \"gusto-ubuntu-default\"}"
+    secrets:
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      npm_token: ${{ secrets.NPM_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+  publish-gusto-embedded-v2025-11-15:
+    uses: Gusto/sdk-generation-action/.github/workflows/sdk-publish.yaml@main
+    with:
+      target: gusto-embedded-v2025-11-15
+      runs-on: "{\"group\": \"gusto-ubuntu-default\"}"
+    secrets:
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      npm_token: ${{ secrets.NPM_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+  publish-gusto-embedded-v2026-06-15:
+    uses: Gusto/sdk-generation-action/.github/workflows/sdk-publish.yaml@main
+    with:
+      target: gusto-embedded-v2026-06-15
       runs-on: "{\"group\": \"gusto-ubuntu-default\"}"
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Speakeasy's code-generation workflow auto-discovers every target in `.speakeasy/workflow.yaml`, but the **publish** workflow does not — each target needs an explicit job or its package never ships. As a result, only the unversioned target was being published; the versioned targets (e.g. `v2025-11-15`, `v2026-06-15`) never published.

This regenerates `.github/workflows/sdk_publish.yaml` with one `publish-<target>` job per publishable target defined in `workflow.yaml`, and adds each target's `gen.lock` to the `on.push.paths` trigger.

## Notes
- Generated by `script/utils/codegen/generate_publish_workflow.rb` in Gusto-Partner-API, which is now invoked automatically by `script/codegen --new-version` so future versions stay wired up.
- All jobs standardized on the `sdk-publish.yaml@main` reusable workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)